### PR TITLE
Fixing background image size when calling setFrame

### DIFF
--- a/AKSegmentedControl/AKSegmentedControl.m
+++ b/AKSegmentedControl/AKSegmentedControl.m
@@ -217,6 +217,15 @@
     [self updateButtons];
 }
 
+- (void)setFrame:(CGRect)frame
+{
+    [super setFrame:frame];
+    [self.backgroundImageView setFrame:(CGRect){
+            self.backgroundImageView.frame.origin,
+            self.backgroundImageView.frame.size.width,
+            self.frame.size.height
+    }];
+}
 
 #pragma mark - Rearranging
 


### PR DESCRIPTION
If you init the segmented control with `CGRectZero` then later resize the control, the background will get stuck with a height of zero and not display.

eg:

``` obj-c
- (id)init
{
    self = [super init];
    if (self) {
       _segmentedControl = [[AKSegmentedControl alloc] initWithFrame:CGRectZero];
    }
    return self;
}
```

...

``` obj-c
   [self.segmentedControl setFrame:(CGRect){10, 0, self.view.frame.size.width-20, 37}];
```

Haven't seen any other issues introduced with this change but let me know if you think of something.
