### PR TITLE
Clear the separator array when removing them from the superview.

### DIFF
--- a/AKSegmentedControl/AKSegmentedControl.m
+++ b/AKSegmentedControl/AKSegmentedControl.m
@@ -169,7 +169,7 @@
     
     _buttonsArray = buttonsArray;
     
-    [_buttonsArray enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+    [_buttonsArray enumerateObjectsWithOptions:nil usingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
          [self addSubview:(UIButton *)obj];
         [(UIButton *)obj addTarget:self action:@selector(segmentButtonPressed:) forControlEvents:UIControlEventTouchDown];
         [(UIButton *)obj setTag:idx];
@@ -227,7 +227,7 @@
     
     NSUInteger separatorsNumber = [_buttonsArray count] - 1;
     
-    [_buttonsArray enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+    [_buttonsArray enumerateObjectsWithOptions:nil usingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         if (idx < separatorsNumber)
         {
             UIImageView *separatorImageView = [[UIImageView alloc] initWithImage:_separatorImage];


### PR DESCRIPTION
When calling rebuildSeparators, the separators are being removed from the view, but not the array.  This is causing separatorsArray to append separatorsNumber objects that do not get placed into the view properly.
