### PR TITLE
Fix crash on iOS7 devices

### DIFF
--- a/AKSegmentedControl/AKSegmentedControl.m
+++ b/AKSegmentedControl/AKSegmentedControl.m
@@ -169,8 +169,8 @@
     
     _buttonsArray = buttonsArray;
     
-    [_buttonsArray enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-         [self addSubview:(UIButton *)obj];
+    [_buttonsArray enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        [self addSubview:(UIButton *)obj];
         [(UIButton *)obj addTarget:self action:@selector(segmentButtonPressed:) forControlEvents:UIControlEventTouchDown];
         [(UIButton *)obj setTag:idx];
     }];


### PR DESCRIPTION
On iOS7 devices, [NSArray enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:] will cause the block to run in background threads, and crashes. Remove the NSEnumerationConcurrent option fixes the crash.
