### PR TITLE
layoutSubviews needs to call super.

### DIFF
--- a/AKSegmentedControl/AKSegmentedControl.m
+++ b/AKSegmentedControl/AKSegmentedControl.m
@@ -71,6 +71,7 @@ static CGFloat const kAKButtonSeparatorWidth = 1.0;
 #pragma mark - Layout
 
 - (void)layoutSubviews {
+    [super layoutSubviews];
     CGRect contentRect = UIEdgeInsetsInsetRect(self.bounds, _contentEdgeInsets);
     
     NSUInteger buttonsCount    = _buttonsArray.count;


### PR DESCRIPTION
I have a crash 'Fatal Exception: NSInternalInconsistencyException
Auto Layout still required after executing -layoutSubviews. AKSegmentedControl's implementation of -layoutSubviews needs to call super.' in iOS 7.

fix it,
